### PR TITLE
Update the styles to be 508 compliant and printable

### DIFF
--- a/source/javascript/start.js
+++ b/source/javascript/start.js
@@ -10,8 +10,12 @@ let ss = document.getElementById( 'js-stage' );
 let btn = document.getElementById( 'save-png-button' );
 btn.addEventListener('click', function() {
   let svgList = ss.getElementsByTagName('svg');
+  let options = {
+    scale: 2,
+    backgroundColor: '#ffffff',
+  };
   if (svgList.length) {
-    svgPng.saveSvgAsPng(svgList[0], document.title+'.png', {scale: 2});
+    svgPng.saveSvgAsPng(svgList[0], document.title+'.png', options);
   }
 });
 

--- a/source/styles/render.scss
+++ b/source/styles/render.scss
@@ -5,6 +5,7 @@
 @import './shell';
 
 .mermaid {
+  background: $color-gray-lightest;
 
   font-family: $font-sans;
 
@@ -22,7 +23,8 @@
 
   rect {
     fill: $color-gray-lightest !important;
-    stroke: $color-gray-lighter !important;
+    stroke: $color-gray-dark !important;
+    stroke-width: 2px !important;
   }
 
   text {
@@ -50,8 +52,12 @@
 }
 
 .edgeLabel {
-  background-color: $color-gray-cool-light;
+  background-color: $color-white;
+  border: $color-white 5px solid;
   color: $color-black;
+  &:empty {
+    border: none;
+  }
 }
 
 rect {


### PR DESCRIPTION
This updates the contrast on borders for `subgraphs` and also adds some background styling for better results when printing backgrounds. ~~Because saving a PNG locally doesn't work, I may need to do some testing on a deployed version of `cg-diagram` to ensure that the backgrounds get saved properly.~~ Fixed in a760fda.