### PR TITLE
rearrange Availability Zone diagrams

### DIFF
--- a/source/diagrams/10-1.2-prod-az.mmd
+++ b/source/diagrams/10-1.2-prod-az.mmd
@@ -3,28 +3,28 @@
 graph LR
   subgraph Availability Zone
     subgraph Public Subnet
-      prod-nat["NAT Gateway"]
-      prod-elb-endpoint>"ELB Endpoint"]
+      nat["NAT Gateway"]
+      elb-endpoint>"ELB Endpoint"]
     end
     subgraph Private Subnet - Core Tier A
-      prod-cf{"CloudFoundry<br>Core Components"}
+      cf{"CloudFoundry<br>Core Components"}
     end
     subgraph Private Subnet - Core Tier B
-      prod-diego{"CloundFoundry<br>Container Management"}
+      diego{"CloundFoundry<br>Container Management"}
     end
     subgraph Private Subnet - Database Tier
-      prod-rds{"RDS instances"}
+      rds{"RDS instances"}
     end
     subgraph Private Subnet - Services Tier
-      prod-services{"Service instances"}
+      services{"Service instances"}
     end
   end
   apps-elb["Customer ELB"]
 
-  apps-elb-->prod-elb-endpoint
+  apps-elb-->elb-endpoint
 
-  prod-nat-->prod-elb-endpoint
-  prod-cf-->prod-nat
-  prod-diego-->prod-nat
-  prod-rds-->prod-nat
-  prod-services-->prod-nat
+  nat-->elb-endpoint
+  cf-->nat
+  diego-->nat
+  rds-->nat
+  services-->nat

--- a/source/diagrams/10-1.2-prod-az.mmd
+++ b/source/diagrams/10-1.2-prod-az.mmd
@@ -23,8 +23,8 @@ graph LR
 
   apps-elb---elb-endpoint
 
-  nat---elb-endpoint
-  cf---nat
-  diego---nat
-  rds---nat
-  services---nat
+  elb-endpoint---nat
+  nat---cf
+  nat---diego
+  nat---rds
+  nat---services

--- a/source/diagrams/10-1.2-prod-az.mmd
+++ b/source/diagrams/10-1.2-prod-az.mmd
@@ -21,10 +21,10 @@ graph LR
   end
   apps-elb["Customer ELB"]
 
-  apps-elb-->elb-endpoint
+  apps-elb---elb-endpoint
 
-  nat-->elb-endpoint
-  cf-->nat
-  diego-->nat
-  rds-->nat
-  services-->nat
+  nat---elb-endpoint
+  cf---nat
+  diego---nat
+  rds---nat
+  services---nat

--- a/source/diagrams/10-1.3-tooling-az.mmd
+++ b/source/diagrams/10-1.3-tooling-az.mmd
@@ -18,9 +18,9 @@ graph LR
   end
   ops-elb["UAA & Concourse ELB"]
 
-  ops-elb-->elb-endpoint
+  ops-elb---elb-endpoint
 
-  nat-->elb-endpoint
-  ops-->nat
-  rds-->nat
-  concourse-->nat
+  nat---elb-endpoint
+  ops---nat
+  rds---nat
+  concourse---nat

--- a/source/diagrams/10-1.3-tooling-az.mmd
+++ b/source/diagrams/10-1.3-tooling-az.mmd
@@ -3,24 +3,24 @@
 graph LR
   subgraph Availability Zone
     subgraph Public Subnet
-      tooling-nat["NAT Gateway"]
-      tooling-elb-endpoint>"ELB Endpoint"]
+      nat["NAT Gateway"]
+      elb-endpoint>"ELB Endpoint"]
     end
     subgraph Private Subnet - Operations Tier
-      tooling-ops["BOSH Director/UAA"]
+      ops["BOSH Director/UAA"]
     end
     subgraph Private Subnet - Database Tier
-      tooling-rds{"RDS instances"}
+      rds{"RDS instances"}
     end
     subgraph Private Subnet - Concourse Tier
-      tooling-concourse["Concourse - production"]
+      concourse["Concourse - production"]
     end
   end
   ops-elb["UAA & Concourse ELB"]
 
-  ops-elb-->tooling-elb-endpoint
+  ops-elb-->elb-endpoint
 
-  tooling-nat-->tooling-elb-endpoint
-  tooling-ops-->tooling-nat
-  tooling-rds-->tooling-nat
-  tooling-concourse-->tooling-nat
+  nat-->elb-endpoint
+  ops-->nat
+  rds-->nat
+  concourse-->nat

--- a/source/diagrams/10-1.3-tooling-az.mmd
+++ b/source/diagrams/10-1.3-tooling-az.mmd
@@ -20,7 +20,7 @@ graph LR
 
   ops-elb---elb-endpoint
 
-  nat---elb-endpoint
-  ops---nat
-  rds---nat
-  concourse---nat
+  elb-endpoint---nat
+  nat---ops
+  nat---rds
+  nat---concourse


### PR DESCRIPTION
Made them flow left-to-right, and have bidirectional arrows. Made similar changes to the Production and Tooling diagrams.

**Before**

![screen shot 2016-10-05 at 11 34 02 pm](https://cloud.githubusercontent.com/assets/86842/19139624/4ac0ea74-8b54-11e6-97eb-d38b9df3b9f6.png)

**After**

![screen shot 2016-10-05 at 11 34 30 pm](https://cloud.githubusercontent.com/assets/86842/19139628/57575eb2-8b54-11e6-9c40-0a915918d417.png)

/cc @NoahKunin @brittag @rogeruiz 