### PR TITLE
Adding note about staging VPC

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -47,7 +47,7 @@ graph LR
         end
         vpc-router-prod["VPC Router"]
       end
-      vpc-peering["VPC Peering Connection"]
+      vpc-peering["VPC Peering Connection<br>(Note: Also peered to Staging VPC,<br>which is architecturally a copy of Production VPC,<br>but outside the cloud.gov Authorization Boundary.)"]
       subgraph Tooling VPC
         subgraph Tooling Availability Zones us-gov-west-1a/b
           subgraph Public Subnet


### PR DESCRIPTION
This is a quick fix to address comment number 18 in the [JAB reviewer comments](https://docs.google.com/spreadsheets/d/1BI9UgFzDSuG6dEPXEvsulga14Lm7hpG8ycpFz26PiYk/edit#gid=406811222) (line 332 of the spreadsheet) - "Where is Staging VPC?  Recommend it be depicted. SSP text states Staging VPC is peered with Tooling VPC. Recommend depict the peering connectivity."

To avoid needing to add the entire Staging VPC as a diagram in the chart, this adds a note explaining the Staging VPC. I added line breaks as hand-line-wrapping; it looks a bit awkward, but probably good enough for now.

cc @jmcarp 