### PR TITLE
Small corrections for compliance

### DIFF
--- a/source/diagrams/10-4.1-customer-data-flow.mmd
+++ b/source/diagrams/10-4.1-customer-data-flow.mmd
@@ -6,12 +6,12 @@ graph LR
       subgraph Container Management
         Cell["Cell"]
         AppContainer{"Customer<br>Application"}
-        Dashboard{Dashboard<br>dashboard.cloud.gov}
+        Dashboard{Dashboard<br>dashboard.fr.cloud.gov}
       end
       Router[Router]
       SSHProxy[SSH Proxy]
-      UAA["User Authentication/Authorization (UAA)<br>login.cloud.gov"]
-      CloudController[Cloud Controller<br>api.cloud.gov]
+      UAA["User Authentication/Authorization (UAA)<br>login.fr.cloud.gov"]
+      CloudController[Cloud Controller<br>api.fr.cloud.gov]
       ServiceBroker[Service Broker]
       Service["Service<br>e.g. MongoDB"]
       HM[Health Monitor]
@@ -22,7 +22,7 @@ graph LR
       Q[Redis Queue]
       Logstash[Logstash]
       ES[Elasticsearch]
-      Kibana[Kibana<br>logs.cloud.gov]
+      Kibana[Kibana<br>logs.fr.cloud.gov]
     end
     ELB("Elastic Load Balancer (ELB)")
     CloudControllerDB(Cloud Controller<br>RDS DB)

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Cloud.gov Diagrams</title>
+    <title>cloud.gov Diagrams</title>
     <link rel="stylesheet" href="render.css">
   </head>
   <body>
-    <h1>Cloud.gov Diagrams</h1>
+    <h1>cloud.gov Diagrams</h1>
     <ul class="scuttle-diagram-list">
     {{ #diagram-list }}
       <li class="scuttle-diagram-list__item">
@@ -15,5 +15,6 @@
       </li>
     {{ /diagram-list }}
     </ul>
+    <p>See <a href="https://github.com/18F/cg-diagrams">cg-diagrams</a> for source code and issue tracker.</p>
   </body>
 </html>


### PR DESCRIPTION
* Include .fr in domains since these are GovCloud diagrams
* Lowercase cloud.gov
* Link to repository from homepage