### PR TITLE
Removing Cloudability and VisualOps from Network diagram

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -9,8 +9,6 @@ graph LR
     statuspage["StatusPage"]
     codeclimate["Code Climate"]
     travis["Travis CI"]
-    cloudability["Cloudability"]
-    visualops["VisualOps"]
   end
   subgraph AWS
     apps-elb["Customer ELB"]
@@ -87,8 +85,6 @@ graph LR
   travis-- Continuous Testing --- github
   prod-nat--Monitoring-->newrelic
   tooling-nat--Alerting-->pagerduty
-  iam--API Read-only for infrastructure visualization-->visualops
-  iam--API Read-only for cost and utilization data-->cloudability
 
   vpc-router-tooling-->vpc-peering
   vpc-router-prod-->vpc-peering


### PR DESCRIPTION
We no longer use Cloudability or VisualOps, so this PR removes them from our Network diagram.

The resulting diagram has rearranged itself, so it looks a bit different from the last version, but at a glance it still looks fine overall to me.

Here's the "save as png" version of the new diagram, which has the wrong font styling (for unknown reasons) but still gives an overall sense of the new diagram:

![10-1-network](https://cloud.githubusercontent.com/assets/391313/20546260/eb4253cc-b0c8-11e6-8250-40b68773f4be.png)