### PR TITLE
Clarify location of staging VPC

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -23,6 +23,9 @@ graph LR
     iam-perms["IAM Permissions"]
     iam-roles["IAM Roles"]
     aws-console["AWS Console"]
+    subgraph Staging VPC
+      staging-vpc{Copy of Production VPC}
+    end
     subgraph cloud.gov Authorization Boundary
       subgraph Production VPC
         subgraph Availability Zones us-gov-west-1a/b
@@ -45,7 +48,7 @@ graph LR
         end
         vpc-router-prod["VPC Router"]
       end
-      vpc-peering["VPC Peering Connection<br>(Note: Also peered to Staging VPC,<br>which is architecturally a copy of Production VPC,<br>but outside the cloud.gov Authorization Boundary.)"]
+      vpc-peering["VPC Peering Connection"]
       subgraph Tooling VPC
         subgraph Tooling Availability Zones us-gov-west-1a/b
           subgraph Public Subnet
@@ -88,6 +91,7 @@ graph LR
 
   vpc-router-tooling-->vpc-peering
   vpc-router-prod-->vpc-peering
+  staging-vpc-->vpc-peering
   aws-console-."Authentication/Authorization".->iam
   iam-.->iam-perms
   iam-perms-.->iam-roles

--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -24,7 +24,7 @@ graph LR
     iam-roles["IAM Roles"]
     aws-console["AWS Console"]
     subgraph Staging VPC
-      staging-vpc{Copy of Production VPC}
+      vpc-staging{Copy of Production VPC}
     end
     subgraph cloud.gov Authorization Boundary
       subgraph Production VPC
@@ -91,7 +91,7 @@ graph LR
 
   vpc-router-tooling-->vpc-peering
   vpc-router-prod-->vpc-peering
-  staging-vpc-->vpc-peering
+  vpc-staging-->vpc-peering
   aws-console-."Authentication/Authorization".->iam
   iam-.->iam-perms
   iam-perms-.->iam-roles


### PR DESCRIPTION
A TR suggested clarifying this diagram: "As the staging VPC is peered with Tooling VPC, recommend depicting the “staging VPC” as an entity within the AWS box."

This is a good point, so I made an effort at this! Here's what it looks like - needs review for accuracy:

![10-1-update](https://cloud.githubusercontent.com/assets/391313/20988403/778df0bc-bc85-11e6-948a-eaa1d61044ae.png)
