### PR TITLE
Add CloudWatch Logs detail to monitoring diagram

### DIFF
--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -1,10 +1,14 @@
 %% title: 10-4.3 Monitoring & Alerting Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Monitoring & Alerting Data Flow
 graph LR
-  subgraph AWS
-    elb["Elastic Load Balancer<br>(ELB)"]
+  subgraph AWS Oregon Region
+    kinesis["AWS Kinesis"]
+  end
+  subgraph AWS GovCloud
+    elb["AWS Elastic Load Balancer<br>(ELB)"]
     UAA["User Authentication/Authorization (UAA)"]
-    aws-logs["CloudWatch"]
+    aws-logs["AWS CloudWatch Logs"]
+    aws-cloudwatch["AWS CloudWatch"]
     aws-console["AWS Console"]
     aws-api["AWS API"]
     aws-iam("AWS IAM")
@@ -19,7 +23,7 @@ graph LR
       clamav{"ClamAV<br>(Virus/Malware)"}
       tripwire{"Tripwire<br>(Filesystem Integrity)"}
       logs("System Logs")
-      aws-logs-agent{"AWS<br>CloudWatch<br>Agent"}
+      aws-logs-agent{"AWS<br>CloudWatch<br>Logs Agent"}
       nragent{"New Relic Agent"}
       snort{"Snort IDS<br>(Intrusion Detection)"}
       boshagent["BOSH Agent"]
@@ -57,7 +61,7 @@ graph LR
   nessus--Reports-->email
   tenable-updates--Security Definition Updates-->nessus
 
-  collectd--System performance metrics-->riemann
+  collectd--System Performance Metrics-->riemann
   firehose-->riemann
   aws-api--AWS Metrics-->boshdirector
   boshagent-->boshdirector
@@ -65,14 +69,16 @@ graph LR
   boshdirector--AWS Metrics-->riemann
 
   tripwire--Sends Report-->logs
-  logs--Reads Logs-->aws-logs-agent
-  aws-logs-agent--Sends Logs-->aws-logs
+  logs--Sends Logs-->aws-logs-agent
+  logs--Sends Performance Metrics-->aws-cloudwatch
+  aws-logs-agent--Sends Encrypted Log Data Only-->kinesis
+  kinesis--Sends Encrypted Log Data Only-->aws-logs
   aws-logs--View Logs-->aws-console
 
   clamav-updates--Security Definition Updates-->clamav
   clamav--Sends Alerts-->riemann
   
-  logs--Sends logs-->riemann
+  logs--Sends Logs-->riemann
 
   snort-updates--Security Definition Updates-->snort
   snort--Sends Alerts-->riemann

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -1,7 +1,7 @@
 %% title: 10-4.3 Monitoring & Alerting Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Monitoring & Alerting Data Flow
 graph LR
-  subgraph AWS West Region
+  subgraph AWS US West Oregon
     kinesis["AWS Kinesis"]
   end
   subgraph AWS GovCloud

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -1,7 +1,7 @@
 %% title: 10-4.3 Monitoring & Alerting Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Monitoring & Alerting Data Flow
 graph LR
-  subgraph AWS West (Oregon) Region
+  subgraph AWS West Region
     kinesis["AWS Kinesis"]
   end
   subgraph AWS GovCloud

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -1,7 +1,7 @@
 %% title: 10-4.3 Monitoring & Alerting Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Monitoring & Alerting Data Flow
 graph LR
-  subgraph AWS Oregon Region
+  subgraph AWS West (Oregon) Region
     kinesis["AWS Kinesis"]
   end
   subgraph AWS GovCloud


### PR DESCRIPTION
This change adds more information about AWS CloudWatch and AWS CloudWatch Logs, including:

* Distinguished between CloudWatch and CloudWatch logs
* Added info about encrypted data sent to Kinesis in US West, based on [this documentation](http://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-cw.html)
* Changed a "Reads Logs" label to "Sends Logs" since that looked like it made more sense, but I could be wrong on that one.

This needs review for technical accuracy before merging.

<img width="897" alt="screen shot 2016-12-15 at 10 33 40 pm" src="https://cloud.githubusercontent.com/assets/391313/21253872/92582768-c316-11e6-89fd-2a4e08bd15dd.png">