### PR TITLE
More information about CloudWatch and AWS for diagrams

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -10,18 +10,24 @@ graph LR
     codeclimate["Code Climate"]
     travis["Travis CI"]
   end
-  subgraph AWS
+  subgraph AWS US West Oregon
+    kinesis["AWS Kinesis"]
+  end  
+  subgraph AWS US East/West
+    route53["AWS Route 53"]
+  end
+  subgraph AWS GovCloud
     apps-elb["Customer ELB"]
     ops-elb["UAA & Concourse ELB"]
-    s3["S3"]
-    cloudwatch["CloudWatch"]
-    advisor["Trusted Advisor"]
-    config["Config"]
-    cloudtrail["CloudTrail"]
-    route53["Route 53"]
-    iam["IAM"]
-    iam-perms["IAM Permissions"]
-    iam-roles["IAM Roles"]
+    s3["AWS S3"]
+    cloudwatch["AWS CloudWatch"]
+    cloudwatch-logs["AWS CloudWatch Logs"]
+    advisor["AWS Trusted Advisor"]
+    config["AWS Config"]
+    cloudtrail["AWS CloudTrail"]
+    iam["AWS IAM"]
+    iam-perms["AWS IAM Permissions"]
+    iam-roles["AWS IAM Roles"]
     aws-console["AWS Console"]
     subgraph Staging VPC
       vpc-staging{Copy of Production VPC}
@@ -40,7 +46,7 @@ graph LR
             prod-diego{"Cloud Foundry<br>Container Management"}
           end
           subgraph Private Subnet - Database Tier
-            prod-rds{"RDS instances"}
+            prod-rds{"AWS RDS instances"}
           end
           subgraph Private Subnet - Services Tier
             prod-services{"Service instances"}
@@ -59,7 +65,7 @@ graph LR
             tooling-ops["BOSH Director/UAA"]
           end
           subgraph Private Subnet - Database Tier
-            tooling-rds{"RDS instances"}
+            tooling-rds{"AWS RDS instances"}
           end
           subgraph Private Subnet - Concourse Tier
             tooling-concourse["Concourse - production"]
@@ -108,3 +114,5 @@ graph LR
   tooling-nat---tooling-ops
   tooling-nat---tooling-rds
   tooling-nat---tooling-concourse
+  
+  cloudwatch-logs-- Encrypted log data only --- kinesis

--- a/source/diagrams/10-4.1-customer-data-flow.mmd
+++ b/source/diagrams/10-4.1-customer-data-flow.mmd
@@ -1,7 +1,7 @@
 %% title: 10-4.1 Customer Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.1 Customer Data Flow
 graph LR
-  subgraph AWS
+  subgraph AWS GovCloud
     subgraph Cloud Foundry Components
       subgraph Container Management
         Cell["Cell"]
@@ -23,9 +23,9 @@ graph LR
       ES[Elasticsearch]
       Kibana[Kibana<br>logs.fr.cloud.gov]
     end
-    ELB("Elastic Load Balancer (ELB)")
-    CloudControllerDB(Cloud Controller<br>RDS DB)
-    CloudWatch[CloudWatch]
+    ELB("AWS Elastic Load Balancer (ELB)")
+    CloudControllerDB(Cloud Controller<br>AWS RDS DB)
+    CloudWatch[AWS CloudWatch Logs]
     S3[S3]
   end
   subgraph Customer Responsibility

--- a/source/diagrams/10-4.2-jumpbox.mmd
+++ b/source/diagrams/10-4.2-jumpbox.mmd
@@ -2,14 +2,14 @@
 %% description: Section 10 - System Environment - Figure 10-4.2 Jumpbox Data Flow
 graph TD
 
-  subgraph AWS
+  subgraph AWS GovCloud
     UAA["User Authentication/Authorization (UAA)"]
     web["Concourse Web Server"]
     worker[Concourse Worker]
     Jumpbox{Ephemeral Jumpbox}
     BOSH[BOSH Director]
-    EC2[EC2 Instances]
-    ELB("Elastic Load Balancer (ELB)")
+    EC2[AWS EC2 Instances]
+    ELB("AWS Elastic Load Balancer (ELB)")
   end
   subgraph GSA Responsibility
     SAML{"Single Sign-on (SSO)<br>providing MFA"}

--- a/source/diagrams/10-4.4-software-deployment.mmd
+++ b/source/diagrams/10-4.4-software-deployment.mmd
@@ -1,17 +1,17 @@
 %% title: 10-4.4 Software Deployment Data Flow
 %% description: Section 10 - System Environment - Figure 10-4.3 Software Deployment Data Flow
 graph TD
-  subgraph AWS
+  subgraph AWS GovCloud
     subgraph Concourse
       web["Concourse Web Server"]
       worker["Concourse Worker"]
       test-job("Test Build")
       deploy-job("Deployment Build")
     end
-    elb["Elastic Load Balancer (ELB)"]
+    elb["AWS Elastic Load Balancer (ELB)"]
     UAA["User Authentication/Authorization (UAA)"]
     bosh["BOSH Director"]
-    ec2["EC2 Instance"]
+    ec2["AWS EC2 Instance"]
   end
   subgraph External
     github["GitHub Repository"]


### PR DESCRIPTION
Simple updates to customer data flow + Jumpbox + Software deployment diagrams:
* Put "AWS" in front of AWS services, for clarity
* Specify that main AWS box is AWS GovCloud

Complex update to network diagram:
* Put "AWS" in front of AWS services, for clarity
* Specify that main AWS box is AWS GovCloud
* Add box for AWS CloudWatch Logs
* Add box for US West Oregon containing AWS Kinesis, connected to AWS CloudWatch Logs
* Add box for US East/West and put AWS Route 53 in it

Network diagram screenshot:

![211633350](https://cloud.githubusercontent.com/assets/391313/21276258/68aacb22-c385-11e6-97a7-346dab388648.png)