### PR TITLE
Style "Save as PNG" diagrams

### DIFF
--- a/source/styles/render.scss
+++ b/source/styles/render.scss
@@ -39,6 +39,8 @@
 
   text {
     @include h4;
+    font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+    font-size: 17px;
   }
 
 }
@@ -50,6 +52,11 @@
   fill: $color-primary;
   stroke: $color-primary-darkest;
   stroke-width: 2px;
+}
+
+.node .label {
+  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+  color: rgb(255, 255, 255);
 }
 
 .edgePath .path {
@@ -68,6 +75,8 @@
   &:empty {
     border: none;
   }
+  font-family: "Source Sans Pro", "Helvetica Neue", "Helvetica", "Roboto", "Arial", sans-serif;
+  font-family: 17px;
 }
 
 rect {


### PR DESCRIPTION
### Issue
This is a CR for #40: the generated-PNG text is not styled as it is originally in the SVG.

### Root Cause
I took a look at save-svg-as-png's `selectorRemap ` and elements like the body are missing from the mapped CSS classes, so the styles for these classes aren't picked up/inherited nor computed at all.

### Solution
The save-svg-as-png module wasn't picking up inherited styles from the body, etc, so it seems that pulling the styles into the lower svg elements works.

Could someone please take a look?

Old:
![old](http://i.imgur.com/NYM8DLO.png)

New:
![new](http://i.imgur.com/avYPWFm.png)

### Remaining TODO
- specifying the font size in px is inexact (i.e. `17rem != 17px`) and as a result some text doesn't fit in node boxes
- I can't determine which font-family that save-svg-as-png is picking up, but it's now some sans serif font