### PR TITLE
Fixes break on forbidden parens

### DIFF
--- a/source/diagrams/10-4.1-customer-data-flow.mmd
+++ b/source/diagrams/10-4.1-customer-data-flow.mmd
@@ -3,7 +3,7 @@
 graph LR
   subgraph AWS GovCloud
     subgraph Cloud Foundry Components
-      subgraph Container Management Segment(s)
+      subgraph Container Management Segments
         Cell["Cell"]
         AppContainer{"Customer<br>Application"}
         Dashboard{Dashboard<br>dashboard.fr.cloud.gov}


### PR DESCRIPTION
Mermaid doesn't allow parens in the title of a subgraph.