### PR TITLE
Notification Refresh in Network and Monitoring Diagrams - Removal of PagerDuty/NewRelic; Replaced with GoogleGroups flows

### DIFF
--- a/source/diagrams/10-1-network.mmd
+++ b/source/diagrams/10-1-network.mmd
@@ -4,10 +4,9 @@ graph LR
   subgraph External Services
     github["GitHub"]
     slack["Slack"]
-    pagerduty["PagerDuty"]
-    newrelic["New Relic"]
     statuspage["StatusPage"]
     codeclimate["Code Climate"]
+    googlegroups["Google Groups"]
     circle["Circle CI"]
   end
   subgraph AWS US West Oregon
@@ -95,14 +94,12 @@ graph LR
   ops-->github
   ops-->slack
   ops---aws-console
-  ops-->newrelic
   ops-->statuspage
-  ops-->pagerduty
+  ops-->googlegroups
 
   codeclimate-- Static analysis --- github
   circle-- Continuous Testing --- github
-  prod-nat--Monitoring-->newrelic
-  tooling-nat--Alerting-->pagerduty
+  tooling-nat--Alerting-->googlegroups
 
   vpc-router-tooling-->vpc-peering
   vpc-router-prod-->vpc-peering

--- a/source/diagrams/10-4.3-monitoring.mmd
+++ b/source/diagrams/10-4.3-monitoring.mmd
@@ -41,16 +41,11 @@ graph LR
     statuspage["StatusPage"]
     sp-account["StatusPage Account"]
     clamav-updates>"ClamAV Updates"]
-    pagerduty["PagerDuty"]
-    pagerduty-account["PagerDuty Account"]
-    new-relic["New Relic"]
-    new-relic-account["New Relic Account"]
+    Googlegroups["Google Groups"]
     snort-updates>"Snort Network<br>Vulnerability Profiles"]
     tenable-updates>"Tenable Updates"]
   end
   email("Email")
-  sms("Text Messages")
-  phone("On Call Phone")
   Ops((Cloud Operations))
 
   nessusagent--Sends Scanning Results-->nessus
@@ -84,25 +79,15 @@ graph LR
 
   prometheus--Visualizes events-->grafana
   elb-->grafana
-  prometheus--Processes alerts-->pagerduty
-  pagerduty-->email
-  pagerduty-->sms
-  pagerduty-->phone
-
-  nragent-->new-relic
-  new-relic-."Authentication/Authorization".->new-relic-account
+  prometheus--Processes alerts-->googlegroups
+  Googlegroups-->email
 
   UAA-.Authentication.->SAML
   grafana-.Authorization.->UAA
 
   aws-console-."Authentication/Authorization".->aws-iam
   statuspage-."Authentication/Authorization".->sp-account
-  pagerduty-."Authentication/Authorization".->pagerduty-account
   email-->Ops
-  sms-->Ops
-  phone-->Ops
   Ops--HTTPS-->elb
   Ops--HTTPS-->aws-console
-  Ops--HTTPS-->new-relic
-  Ops--HTTPS-->statuspage
-  Ops--HTTPS-->pagerduty
+  Ops--HTTPS-->googlegroups


### PR DESCRIPTION
Please review and approve (when confirmed) the removal of PagerDuty and NewRelic and adding Google Groups alerting/email in the design documents. 