### PR TITLE
Unpack public/ so it's accessible

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,5 +8,6 @@ npm run build
 
 # copy files to output directory, so that they can be read by subsequent step
 if [ -n "$COPY_OUTPUT" ]; then
-  cp -R . ../cg-diagrams-compiled
+  cp -R public ../cg-diagrams-compiled
+  cp manifest.yml ../cg-diagrams-compiled
 fi

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -8,6 +8,6 @@ npm run build
 
 # copy files to output directory, so that they can be read by subsequent step
 if [ -n "$COPY_OUTPUT" ]; then
-  cp -R public ../cg-diagrams-compiled
+  cp -R public/* ../cg-diagrams-compiled
   cp manifest.yml ../cg-diagrams-compiled
 fi


### PR DESCRIPTION
Something changed somewhere, and I don't pretend to know what, but it seems like whatever it was has to do with how paths are handled. 
What we were ending up with was that `/home/vcap/app/public` contained the whole `cg-diagrams-compiled` directory, except `cg-diagrams-compiled/public/` was empty.

This change copies only the _contents of_ `public` and `maniifest.yml` into `cg-diagrams-compiled`.
This fixes the problem we're having, with a side-benefit of a smaller image (we're leaving behind all the JS fixtures, ci stuff, READMEs, etc)